### PR TITLE
Convert height and weight values to be human readable

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@ type Pokemon struct {
 	ID     int    `njson:"id"`
 	Height int    `njson:"height"`
 	Weight int    `njson:"weight"`
-	Type_1 string `njson:"types.0.type.name"`
-	Type_2 string `njson:"types.1.type.name"`
+	Type1  string `njson:"types.0.type.name"`
+	Type2  string `njson:"types.1.type.name"`
 }
 
 func main() {
@@ -35,11 +35,11 @@ func show(pokemon Pokemon) {
 	fmt.Println("Height:", convertDecimetersToMeters(pokemon.Height))
 	fmt.Println("Weight:", pokemon.Weight)
 
-	if pokemon.Type_2 == "" {
-		fmt.Println("Type:", pokemon.Type_1)
+	if pokemon.Type2 == "" {
+		fmt.Println("Type:", pokemon.Type1)
 	} else {
-		fmt.Println("Type 1:", pokemon.Type_1)
-		fmt.Println("Type 2:", pokemon.Type_2)
+		fmt.Println("Type 1:", pokemon.Type1)
+		fmt.Println("Type 2:", pokemon.Type2)
 	}
 }
 
@@ -76,9 +76,9 @@ func createPokemon(name string) Pokemon {
 		fmt.Println(err)
 	}
 
-	pokeJson.Name = strings.Title(pokeJson.Name)
-	pokeJson.Type_1 = strings.Title(pokeJson.Type_1)
-	pokeJson.Type_2 = strings.Title(pokeJson.Type_2)
+	pokeJson.Name = strings.ToTitle(pokeJson.Name)
+	pokeJson.Type1 = strings.ToTitle(pokeJson.Type1)
+	pokeJson.Type2 = strings.ToTitle(pokeJson.Type2)
 
 	return pokeJson
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func show(pokemon Pokemon) {
 	fmt.Println("National Pokédex number:", pokemon.ID)
 
 	fmt.Println("Height:", convertDecimetersToMeters(pokemon.Height))
-	fmt.Println("Weight:", pokemon.Weight)
+	fmt.Println("Weight:", convertHectogramsToKilograms(pokemon.Weight))
 
 	if pokemon.Type2 == "" {
 		fmt.Println("Type:", pokemon.Type1)
@@ -50,6 +50,19 @@ func convertDecimetersToMeters(height int) string {
 		return fmt.Sprintf("%g", adjustedHeight) + "m"
 	} else {
 		return "0." + strconv.Itoa(height) + "m"
+	}
+}
+
+func convertHectogramsToKilograms(weight int) string {
+	if weight >= 10 {
+		var weightAsFloat = float64(weight)
+		var adjustedWeight = weightAsFloat / float64(10)
+		return fmt.Sprintf("%g", adjustedWeight) + "kg"
+	} else {
+		var weightAsFloat = float64(weight)
+		var adjustedWeight = weightAsFloat * 2.2
+		var weightAsPounds = adjustedWeight / float64(10)
+		return fmt.Sprintf("%.1f", weightAsPounds) + "lbs"
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func show(pokemon Pokemon) {
 	fmt.Println("Name:", pokemon.Name)
 	fmt.Println("National Pokédex number:", pokemon.ID)
 
-	fmt.Println("Height:", pokemon.Height)
+	fmt.Println("Height:", convertDecimetersToMeters(pokemon.Height))
 	fmt.Println("Weight:", pokemon.Weight)
 
 	if pokemon.Type_2 == "" {
@@ -39,6 +40,14 @@ func show(pokemon Pokemon) {
 	} else {
 		fmt.Println("Type 1:", pokemon.Type_1)
 		fmt.Println("Type 2:", pokemon.Type_2)
+	}
+}
+
+func convertDecimetersToMeters(height int) string {
+	if height >= 10 {
+		//
+	} else {
+		return "0." + strconv.Itoa(height) + "m"
 	}
 }
 
@@ -66,18 +75,5 @@ func createPokemon(name string) Pokemon {
 	pokeJson.Type_1 = strings.Title(pokeJson.Type_1)
 	pokeJson.Type_2 = strings.Title(pokeJson.Type_2)
 
-	pokeJsonHeight := convertHeight(pokeJson.Height)
-	pokeJson.Height = pokeJsonHeight
-
 	return pokeJson
-}
-
-func convertHeight(height int) string {
-	fmt.Println(height)
-
-	if height >= 10 {
-		return "higher than or equal to 10"
-	} else {
-		return "lower than 10"
-	}
 }

--- a/main.go
+++ b/main.go
@@ -45,12 +45,9 @@ func show(pokemon Pokemon) {
 
 func convertDecimetersToMeters(height int) string {
 	if height >= 10 {
-		heightSlice := []int{}
-		for height > 0 {
-			heightSlice = append(heightSlice, height%10)
-			height = height / 10
-		}
-		return strings.Trim(strings.Replace(fmt.Sprint(heightSlice), " ", delim, -1), "[]")
+		var heightAsFloat = float64(height)
+		var adjustedHeight = heightAsFloat / float64(10)
+		return fmt.Sprintf("%g", adjustedHeight) + "m"
 	} else {
 		return "0." + strconv.Itoa(height) + "m"
 	}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,12 @@ func show(pokemon Pokemon) {
 
 func convertDecimetersToMeters(height int) string {
 	if height >= 10 {
-		//
+		heightSlice := []int{}
+		for height > 0 {
+			heightSlice = append(heightSlice, height%10)
+			height = height / 10
+		}
+		return strings.Trim(strings.Replace(fmt.Sprint(heightSlice), " ", delim, -1), "[]")
 	} else {
 		return "0." + strconv.Itoa(height) + "m"
 	}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/m7shapan/njson"

--- a/main.go
+++ b/main.go
@@ -66,5 +66,18 @@ func createPokemon(name string) Pokemon {
 	pokeJson.Type_1 = strings.Title(pokeJson.Type_1)
 	pokeJson.Type_2 = strings.Title(pokeJson.Type_2)
 
+	pokeJsonHeight := convertHeight(pokeJson.Height)
+	pokeJson.Height = pokeJsonHeight
+
 	return pokeJson
+}
+
+func convertHeight(height int) string {
+	fmt.Println(height)
+
+	if height >= 10 {
+		return "higher than or equal to 10"
+	} else {
+		return "lower than 10"
+	}
 }


### PR DESCRIPTION
Height and weight values returned from [the API](https://pokeapi.co/docs/v2#pokemon) are not human readable. Heights are in decimetres, whilst weight is returned in hectograms. 

This PR attempts to convert these integers into more human-readable forms. Heights are now returned in meters, whilst weights are returned in pounds or kilograms (depending on which is most appropriate)

![image](https://user-images.githubusercontent.com/10532380/201385658-f5165822-62d9-4032-8c22-45c2181fc293.png)

![image](https://user-images.githubusercontent.com/10532380/201385711-1444ff9f-b3e9-40d4-b6d3-586c5a0bd775.png)
