### PR TITLE
Ignore the index when looping through Pokemon's abilities

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,9 +50,8 @@ func show(pokemon Pokemon) {
 	}
 
 	fmt.Println("----- Abilities -----")
-	for i, pokemonAbilities := range pokemon.Abilities {
+	for _, pokemonAbilities := range pokemon.Abilities {
 		printPokemonAbilities(pokemonAbilities)
-		i++
 	}
 }
 


### PR DESCRIPTION
By using `_` before the `pokemonAbilities` array in this iteration loop, we can safely ignore the index of the array items and deal with the object itself.