### PR TITLE
Shift display of Pokémon data

### DIFF
--- a/app/helpers.go
+++ b/app/helpers.go
@@ -2,8 +2,14 @@ package app
 
 import (
 	"fmt"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"strconv"
 )
+
+func ConvertStringToTitleCase(stringToConvert string) string {
+	return cases.Title(language.Und, cases.NoLower).String(stringToConvert)
+}
 
 func ConvertDecimetersToMeters(height int) string {
 	if height >= 10 {

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -36,5 +36,5 @@ func printPokemonAbilities(pokemonAbility models.Ability) {
 		fmt.Print("Ability ", pokemonAbility.Slot, ":")
 	}
 
-	fmt.Printf(" %+v\n", strings.ToTitle(pokemonAbility.Name))
+	fmt.Printf(" %+v\n", pokemonAbility.Name)
 }

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -15,9 +15,7 @@ func Show(pokemon models.Pokemon) {
 
 	fmt.Println("------- Types -------")
 	for _, pokemonTypes := range pokemon.Types {
-		fmt.Print("Type ", pokemonTypes.Slot, ":")
-
-		fmt.Printf(" %+v\n", strings.ToTitle(pokemonTypes.Name))
+		printPokemonTypes(pokemonTypes)
 	}
 
 	fmt.Println("----- Abilities -----")
@@ -26,12 +24,18 @@ func Show(pokemon models.Pokemon) {
 	}
 }
 
-func printPokemonAbilities(ability models.Ability) {
-	if ability.IsHidden == true {
+func printPokemonTypes(pokemonType models.Type) {
+	fmt.Print("Type ", pokemonType.Slot, ":")
+
+	fmt.Printf(" %+v\n", strings.ToTitle(pokemonType.Name))
+}
+
+func printPokemonAbilities(pokemonAbility models.Ability) {
+	if pokemonAbility.IsHidden == true {
 		fmt.Print("Hidden Ability:")
 	} else {
-		fmt.Print("Ability ", ability.Slot, ":")
+		fmt.Print("Ability ", pokemonAbility.Slot, ":")
 	}
 
-	fmt.Printf(" %+v\n", strings.ToTitle(ability.Name))
+	fmt.Printf(" %+v\n", strings.ToTitle(pokemonAbility.Name))
 }

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -3,11 +3,10 @@ package app
 import (
 	"fmt"
 	"github.com/kerrance/go-hisui/app/models"
-	"strings"
 )
 
 func Show(pokemon models.Pokemon) {
-	fmt.Println("Name:", pokemon.Name)
+	fmt.Println("Name:", ConvertStringToTitleCase(pokemon.Name))
 	fmt.Println("National Pokédex number:", pokemon.ID)
 
 	fmt.Println("Height:", ConvertDecimetersToMeters(pokemon.Height))
@@ -27,7 +26,7 @@ func Show(pokemon models.Pokemon) {
 func printPokemonTypes(pokemonType models.Type) {
 	fmt.Print("Type ", pokemonType.Slot, ":")
 
-	fmt.Printf(" %+v\n", strings.ToTitle(pokemonType.Name))
+	fmt.Printf(" %+v\n", ConvertStringToTitleCase(pokemonType.Name))
 }
 
 func printPokemonAbilities(pokemonAbility models.Ability) {

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+	"github.com/kerrance/go-hisui/app/models"
+	"strings"
+)
+
+func Show(pokemon models.Pokemon) {
+	fmt.Println("Name:", pokemon.Name)
+	fmt.Println("National Pokédex number:", pokemon.ID)
+
+	fmt.Println("Height:", ConvertDecimetersToMeters(pokemon.Height))
+	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
+
+	fmt.Println("------- Types -------")
+	for _, pokemonTypes := range pokemon.Types {
+		fmt.Print("Type ", pokemonTypes.Slot, ":")
+
+		fmt.Printf(" %+v\n", strings.ToTitle(pokemonTypes.Name))
+	}
+
+	fmt.Println("----- Abilities -----")
+	for _, pokemonAbilities := range pokemon.Abilities {
+		printPokemonAbilities(pokemonAbilities)
+	}
+}
+
+func printPokemonAbilities(ability models.Ability) {
+	if ability.IsHidden == true {
+		fmt.Print("Hidden Ability:")
+	} else {
+		fmt.Print("Ability ", ability.Slot, ":")
+	}
+
+	fmt.Printf(" %+v\n", strings.ToTitle(ability.Name))
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/kerrance/go-hisui
 
 go 1.18
 
-require github.com/m7shapan/njson v1.0.8
+require (
+	github.com/m7shapan/njson v1.0.8
+	golang.org/x/text v0.8.0
+)
 
 require (
 	github.com/tidwall/gjson v1.14.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,4 +10,6 @@ github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
+golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/kerrance/go-hisui/app"
-	"github.com/kerrance/go-hisui/app/models"
 	"log"
-	"strings"
 )
 
 func main() {
@@ -18,35 +16,5 @@ func main() {
 		log.Fatal("An unexpected error occurred:", err)
 	}
 
-	show(app.FindPokemon(enteredPokemonNameOrPokedexNumber))
-}
-
-func show(pokemon models.Pokemon) {
-	fmt.Println("Name:", pokemon.Name)
-	fmt.Println("National Pokédex number:", pokemon.ID)
-
-	fmt.Println("Height:", app.ConvertDecimetersToMeters(pokemon.Height))
-	fmt.Println("Weight:", app.ConvertHectogramsToKilograms(pokemon.Weight))
-
-	fmt.Println("------- Types -------")
-	for _, pokemonTypes := range pokemon.Types {
-		fmt.Print("Type ", pokemonTypes.Slot, ":")
-
-		fmt.Printf(" %+v\n", strings.ToTitle(pokemonTypes.Name))
-	}
-
-	fmt.Println("----- Abilities -----")
-	for _, pokemonAbilities := range pokemon.Abilities {
-		printPokemonAbilities(pokemonAbilities)
-	}
-}
-
-func printPokemonAbilities(ability models.Ability) {
-	if ability.IsHidden == true {
-		fmt.Print("Hidden Ability:")
-	} else {
-		fmt.Print("Ability ", ability.Slot, ":")
-	}
-
-	fmt.Printf(" %+v\n", strings.ToTitle(ability.Name))
+	app.Show(app.FindPokemon(enteredPokemonNameOrPokedexNumber))
 }


### PR DESCRIPTION
This lifts and shifts the display of Pokémon data into its own transformer class. This will allow for more types of data display without muddying up the main command.

I've also (finally!) been able to introduce a new helper method which converts a string to Title Case.