### PR TITLE
Improve the display of multiple abilities and types

### DIFF
--- a/app/models/ability.go
+++ b/app/models/ability.go
@@ -1,7 +1,7 @@
 package models
 
 type Ability struct {
-	Slot     uint8  `njson:"slot"`
+	Number   uint8  `njson:"slot"`
 	Name     string `njson:"ability.name"`
 	IsHidden bool   `njson:"is_hidden"`
 }

--- a/app/models/type.go
+++ b/app/models/type.go
@@ -1,6 +1,6 @@
 package models
 
 type Type struct {
-	Slot uint8  `njson:"slot"`
-	Name string `njson:"type.name"`
+	Number uint8  `njson:"slot"`
+	Name   string `njson:"type.name"`
 }

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -23,7 +23,7 @@ func Show(pokemon models.Pokemon) {
 
 	fmt.Println("----- Abilities -----")
 	if (len(pokemon.Abilities) == 2) && (pokemon.Abilities[0].Name == pokemon.Abilities[1].Name) {
-		fmt.Print("Ability: ")
+		fmt.Print("Ability:")
 		_, err := printPokemonAbility(pokemon.Abilities[0])
 		if err != nil {
 			return

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -13,25 +13,33 @@ func Show(pokemon models.Pokemon) {
 	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
 
 	fmt.Println("------- Types -------")
-	singleType := true
-	if len(pokemon.Types) > 1 {
-		singleType = false
+	singleType := false
+	if len(pokemon.Types) == 1 {
+		singleType = true
 	}
 	for _, pokemonTypes := range pokemon.Types {
 		printPokemonTypes(pokemonTypes, singleType)
 	}
 
 	fmt.Println("----- Abilities -----")
-	for _, pokemonAbilities := range pokemon.Abilities {
-		printPokemonAbilities(pokemonAbilities)
+	if (len(pokemon.Abilities) == 2) && (pokemon.Abilities[0].Name == pokemon.Abilities[1].Name) {
+		fmt.Print("Ability: ")
+		_, err := printPokemonAbility(pokemon.Abilities[0])
+		if err != nil {
+			return
+		}
+	} else {
+		for _, pokemonAbilities := range pokemon.Abilities {
+			printPokemonAbilities(pokemonAbilities)
+		}
 	}
 }
 
 func printPokemonTypes(pokemonType models.Type, singleType bool) {
-	if singleType == false {
-		fmt.Print("Type ", pokemonType.Number, ":")
-	} else {
+	if singleType == true {
 		fmt.Print("Type:")
+	} else {
+		fmt.Print("Type ", pokemonType.Number, ":")
 	}
 
 	fmt.Printf(" %+v\n", ConvertStringToTitleCase(pokemonType.Name))

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -13,8 +13,12 @@ func Show(pokemon models.Pokemon) {
 	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
 
 	fmt.Println("------- Types -------")
+	moreThanOneType := false
+	if len(pokemon.Types) > 1 {
+		moreThanOneType = true
+	}
 	for _, pokemonTypes := range pokemon.Types {
-		printPokemonTypes(pokemonTypes)
+		printPokemonTypes(pokemonTypes, moreThanOneType)
 	}
 
 	fmt.Println("----- Abilities -----")
@@ -23,8 +27,12 @@ func Show(pokemon models.Pokemon) {
 	}
 }
 
-func printPokemonTypes(pokemonType models.Type) {
-	fmt.Print("Type ", pokemonType.Slot, ":")
+func printPokemonTypes(pokemonType models.Type, single bool) {
+	if single == true {
+		fmt.Print("Type ", pokemonType.Number, ":")
+	} else {
+		fmt.Print("Type:")
+	}
 
 	fmt.Printf(" %+v\n", ConvertStringToTitleCase(pokemonType.Name))
 }

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -13,12 +13,12 @@ func Show(pokemon models.Pokemon) {
 	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
 
 	fmt.Println("------- Types -------")
-	moreThanOneType := false
+	singleType := true
 	if len(pokemon.Types) > 1 {
-		moreThanOneType = true
+		singleType = false
 	}
 	for _, pokemonTypes := range pokemon.Types {
-		printPokemonTypes(pokemonTypes, moreThanOneType)
+		printPokemonTypes(pokemonTypes, singleType)
 	}
 
 	fmt.Println("----- Abilities -----")
@@ -27,8 +27,8 @@ func Show(pokemon models.Pokemon) {
 	}
 }
 
-func printPokemonTypes(pokemonType models.Type, single bool) {
-	if single == true {
+func printPokemonTypes(pokemonType models.Type, singleType bool) {
+	if singleType == false {
 		fmt.Print("Type ", pokemonType.Number, ":")
 	} else {
 		fmt.Print("Type:")

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -33,7 +33,7 @@ func printPokemonAbilities(pokemonAbility models.Ability) {
 	if pokemonAbility.IsHidden == true {
 		fmt.Print("Hidden Ability:")
 	} else {
-		fmt.Print("Ability ", pokemonAbility.Slot, ":")
+		fmt.Print("Ability ", pokemonAbility.Number, ":")
 	}
 
 	fmt.Printf(" %+v\n", pokemonAbility.Name)

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -52,5 +52,12 @@ func printPokemonAbilities(pokemonAbility models.Ability) {
 		fmt.Print("Ability ", pokemonAbility.Number, ":")
 	}
 
-	fmt.Printf(" %+v\n", pokemonAbility.Name)
+	_, err := printPokemonAbility(pokemonAbility)
+	if err != nil {
+		return
+	}
+}
+
+func printPokemonAbility(pokemonAbility models.Ability) (int, error) {
+	return fmt.Printf(" %+v\n", pokemonAbility.Name)
 }


### PR DESCRIPTION
I noticed that there are occasions where a Pokémon will only have one type, or where they will have two abilities, but the standard ability matches their hidden ability. So, this change ensures a neater display in those edge-cases.

For example, a Pokemon like Charizard which has two types, will still display both:

![image](https://user-images.githubusercontent.com/10532380/225910876-16b1bdc7-6f8a-4579-b16c-9684a90b0d6e.png)

But, a Pokemon like Pikachu, which has only one type, will now infer that it has a single type in the label wording:

![image](https://user-images.githubusercontent.com/10532380/225911004-fe3e88e8-9eb3-408b-86a9-50783204ceec.png)

Additionally, with a Pokemon like Gholdengo, who's Hidden Ability is the same as their standard ability, the application will now only show that single ability:

![image](https://user-images.githubusercontent.com/10532380/225911185-0328a6d9-4a35-4f29-b4e3-5ede620026a3.png)
