### PR TITLE
Ensure Pokedex numbers are printed with prefixed zeros

### DIFF
--- a/app/transformer.go
+++ b/app/transformer.go
@@ -7,8 +7,7 @@ import (
 
 func Show(pokemon models.Pokemon) {
 	fmt.Println("Name:", ConvertStringToTitleCase(pokemon.Name))
-	fmt.Println("National Pokédex number:", pokemon.ID)
-
+	fmt.Printf("National Pokédex number: %0*d\n", 4, pokemon.ID)
 	fmt.Println("Height:", ConvertDecimetersToMeters(pokemon.Height))
 	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	var enteredPokemonNameOrPokedexNumber string
 
-	fmt.Println("Search for a Pokémon by name: ")
+	fmt.Println("Search for a Pokémon by name, or National Pokédex number:")
 
 	_, err := fmt.Scanf("%s", &enteredPokemonNameOrPokedexNumber)
 	if err != nil {


### PR DESCRIPTION
This change ensures that national Pokedex numbers are display with 4 digits (see screenshot)

![image](https://user-images.githubusercontent.com/10532380/225915161-68e19057-529f-4b58-a11e-85b78063fdc5.png)

I've also changed the main command prompt to show that Pokemon can be searched with their National Pokedex number as well as their name.