### PR TITLE
Interpret multi-word name inputs

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -7,13 +7,11 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strings"
 )
 
 func FindPokemon(enteredPokemonNameOrPokedexNumber string) models.Pokemon {
 	pokemonApiUrl := "https://pokeapi.co/api/v2/pokemon/"
-	req, _ := http.Get(pokemonApiUrl + strings.ToLower(enteredPokemonNameOrPokedexNumber))
-
+	req, _ := http.Get(pokemonApiUrl + ConvertStringToKebabCase(enteredPokemonNameOrPokedexNumber))
 	if req.StatusCode != 200 {
 		log.Fatalln("Pokémon not found. Please correct your search term and try again.")
 	}

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -5,10 +5,11 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 	"strconv"
+	"strings"
 )
 
 func ConvertStringToTitleCase(stringToConvert string) string {
-	return cases.Title(language.Und, cases.NoLower).String(stringToConvert)
+	return cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(stringToConvert, "-", " "))
 }
 
 func ConvertDecimetersToMeters(height int) string {

--- a/app/helpers.go
+++ b/app/helpers.go
@@ -12,6 +12,10 @@ func ConvertStringToTitleCase(stringToConvert string) string {
 	return cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(stringToConvert, "-", " "))
 }
 
+func ConvertStringToKebabCase(stringToConvert string) string {
+	return strings.ToLower(strings.ReplaceAll(stringToConvert, " ", "-"))
+}
+
 func ConvertDecimetersToMeters(height int) string {
 	if height >= 10 {
 		var heightAsFloat = float64(height)

--- a/main.go
+++ b/main.go
@@ -1,20 +1,22 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/kerrance/go-hisui/app"
 	"log"
+	"os"
+	"strings"
 )
 
 func main() {
-	var enteredPokemonNameOrPokedexNumber string
-
 	fmt.Println("Search for a Pokémon by name, or National Pokédex number:")
 
-	_, err := fmt.Scanf("%s", &enteredPokemonNameOrPokedexNumber)
+	consoleInput, err := bufio.NewReader(os.Stdin).ReadString('\n')
 	if err != nil {
 		log.Fatal("An unexpected error occurred:", err)
 	}
+	enteredPokemonNameOrPokedexNumber := strings.TrimSuffix(consoleInput, "\n")
 
 	app.Show(app.FindPokemon(enteredPokemonNameOrPokedexNumber))
 }


### PR DESCRIPTION
I noticed during my testing that when entering Pokemon names with more than one word, like "Scream Tail" or "Iron Leaves", that only the first word was interpreted and the second word is printed in the terminal after the search fails.

![image](https://user-images.githubusercontent.com/10532380/227516304-25e340cb-342f-49a6-ade5-d531cce17e5c.png)

This change will ensure that names with more than one word can be interpreted.

![image](https://user-images.githubusercontent.com/10532380/227516507-041dfaca-112d-4824-8235-5ea87571da92.png)

**References**

- https://stackoverflow.com/questions/8689245/replace-all-spaces-in-a-string-with
- https://www.golinuxcloud.com/golang-parse-multiple-inputs/