### PR TITLE
Print some Pokemon names with a hyphen

### DIFF
--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -1,0 +1,19 @@
+package app
+
+func CheckPokemonNameShouldBeHyphenated(pokemonName string) bool {
+	switch pokemonName {
+	case
+		"chi-yu",
+		"chien-pao",
+		"hakamo-o",
+		"ho-oh",
+		"jangmo-o",
+		"kommo-o",
+		"porygon-z",
+		"ting-lu",
+		"wo-chien":
+		return true
+	}
+
+	return false
+}

--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -1,6 +1,6 @@
 package app
 
-func CheckPokemonNameShouldBeHyphenated(pokemonName string) bool {
+func ShouldPokemonNameBeHyphenated(pokemonName string) bool {
 	switch pokemonName {
 	case
 		"chi-yu",

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -36,25 +36,13 @@ func Show(pokemon models.Pokemon) {
 }
 
 func printPokemonName(pokemonName string) {
-	switch pokemonName {
-	case "ho-oh":
-	case "porygon-z":
-	case "jangmo-o":
-	case "hakamo-o":
-	case "kommo-o":
-	case "ting-lu":
-	case "chien-pao":
-	case "wo-chien":
-	case "chi-yu":
-		fmt.Println("matched")
-		ConvertStringToTitleCase(pokemonName)
-		pokemonName = strings.ReplaceAll(pokemonName, " ", "-")
-	default:
-		fmt.Println("not matched")
-		pokemonName = ConvertStringToTitleCase(pokemonName)
+	transformedPokemonName := ConvertStringToTitleCase(pokemonName)
+
+	if CheckPokemonNameShouldBeHyphenated(pokemonName) == true {
+		transformedPokemonName = strings.ReplaceAll(transformedPokemonName, " ", "-")
 	}
 
-	fmt.Println("Name:", pokemonName)
+	fmt.Println("Name:", transformedPokemonName)
 }
 
 func printPokemonTypes(pokemonType models.Type, singleType bool) {

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -38,7 +38,7 @@ func Show(pokemon models.Pokemon) {
 func printPokemonName(pokemonName string) {
 	transformedPokemonName := ConvertStringToTitleCase(pokemonName)
 
-	if CheckPokemonNameShouldBeHyphenated(pokemonName) == true {
+	if ShouldPokemonNameBeHyphenated(pokemonName) == true {
 		transformedPokemonName = strings.ReplaceAll(transformedPokemonName, " ", "-")
 	}
 

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -3,10 +3,11 @@ package app
 import (
 	"fmt"
 	"github.com/kerrance/go-hisui/app/models"
+	"strings"
 )
 
 func Show(pokemon models.Pokemon) {
-	fmt.Println("Name:", ConvertStringToTitleCase(pokemon.Name))
+	printPokemonName(pokemon.Name)
 	fmt.Printf("National Pokédex number: %0*d\n", 4, pokemon.ID)
 	fmt.Println("Height:", ConvertDecimetersToMeters(pokemon.Height))
 	fmt.Println("Weight:", ConvertHectogramsToKilograms(pokemon.Weight))
@@ -32,6 +33,28 @@ func Show(pokemon models.Pokemon) {
 			printPokemonAbilities(pokemonAbilities)
 		}
 	}
+}
+
+func printPokemonName(pokemonName string) {
+	switch pokemonName {
+	case "ho-oh":
+	case "porygon-z":
+	case "jangmo-o":
+	case "hakamo-o":
+	case "kommo-o":
+	case "ting-lu":
+	case "chien-pao":
+	case "wo-chien":
+	case "chi-yu":
+		fmt.Println("matched")
+		ConvertStringToTitleCase(pokemonName)
+		pokemonName = strings.ReplaceAll(pokemonName, " ", "-")
+	default:
+		fmt.Println("not matched")
+		pokemonName = ConvertStringToTitleCase(pokemonName)
+	}
+
+	fmt.Println("Name:", pokemonName)
 }
 
 func printPokemonTypes(pokemonType models.Type, singleType bool) {


### PR DESCRIPTION
This change creates a list of 'exemptions' which will ensure that Pokemon with intentionally hyphenated names can be displayed correctly, whilst those with more than one word but with spaces will also display as intended.

For example, "Iron Leaves" will appear with a space, whilst "Porygon-Z" will appear hyphenated but can be searched with by typing either `porygon z` or `porygon-z` by the user.

![image](https://user-images.githubusercontent.com/10532380/229097323-1d222081-a9cd-4054-aa6e-4a46ec84b059.png)
