### PR TITLE
Test that Pokémon names will be printed with a hypen if intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ all the automated tests bundled within the application.
 
 - [PokéAPI](https://pokeapi.co/)
 - [MicroDex](https://github.com/404a10/MicroDex) for inspiration
-- [Joe Sweeny](https://github.com/joesweeny), [Thomas Hockaday](https://github.com/thomashockaday) and
-[Neil Davies](https://github.com/NeilDavies92) for their guidance whilst I have been learning Go
+- [Joe Sweeny](https://github.com/joesweeny), [Thomas Hockaday](https://github.com/thomashockaday),
+[Frazer Lillie](https://github.com/fillie), [Neil Davies](https://github.com/NeilDavies92) and
+[Sam Langley](https://github.com/samlangley1) for their guidance whilst I have been learning Go

--- a/README.md
+++ b/README.md
@@ -7,14 +7,19 @@ All Pokémon information is retrieved from [PokéAPI](https://pokeapi.co/).
 For now, this application will only run locally on your device. In the future, I would like to provide an easier method
 for running this application.
 
-# How to run
-
 Firstly, you will need to [install Go](https://go.dev/doc/install) on your device. Secondly, you will need to download
 the files from this repository to your device, I recommend you use Git by running
 `git clone git@github.com:kerrance/go-hisui.git`.
 
-You can then boot up your Terminal and navigate to the directory folder. You will then be able to run `go run main.go`
-to start the application in your terminal window.
+# How to run the application
+
+Once Go is installed, you can boot up your Terminal and navigate to the directory folder. You will then be able to run
+`go run main.go` to start the application in your terminal window.
+
+# How to test the application
+
+Following the instructions above to run the application, from the root directory, you can enter `go test ./...` to run
+all the automated tests bundled within the application.
 
 # Credits
 

--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -1,7 +1,9 @@
 package app
 
+import "strings"
+
 func ShouldPokemonNameBeHyphenated(pokemonName string) bool {
-	switch pokemonName {
+	switch strings.ToLower(pokemonName) {
 	case
 		"chi-yu",
 		"chien-pao",

--- a/app/exemptions_test.go
+++ b/app/exemptions_test.go
@@ -1,0 +1,44 @@
+package app_test
+
+import (
+	"github.com/kerrance/go-hisui/app"
+	"testing"
+)
+
+func TestShouldPokemonNameBeHyphenated(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"Provide a hypenated Pokémon name", "chi-yu", true},
+		{"Provide a hypenated Pokémon name", "chien-pao", true},
+		{"Provide a hypenated Pokémon name", "hakamo-o", true},
+		{"Provide a hypenated Pokémon name", "HO-OH", true},
+		{"Provide a hypenated Pokémon name", "jangmo-o", true},
+		{"Provide a hypenated Pokémon name", "kommo-o", true},
+		{"Provide a hypenated Pokémon name", "PORYGON-Z", true},
+		{"Provide a hypenated Pokémon name", "ting-lu", true},
+		{"Provide a hypenated Pokémon name", "wo-CHIEN", true},
+		{"Provide a non-hypenated Pokémon name", "pikachu", false},
+		{"Provide a non-hypenated Pokémon name", "CHARIZARD", false},
+		{"Provide a non-hypenated Pokémon name", "mr. mime", false},
+		{"Provide a non-hypenated Pokémon name", "type: null", false},
+		{"Provide a non-hypenated Pokémon name", "iron LEAVES", false},
+		{"Provide a non-hypenated Pokémon name", "mew two", false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(testing *testing.T) {
+			result := app.ShouldPokemonNameBeHyphenated(testCase.input)
+			if result != testCase.expected {
+				testing.Errorf(
+					"Expected ShouldPokemonNameBeHyphenated(%q) to be %v, but got %v",
+					testCase.input,
+					testCase.expected,
+					result,
+				)
+			}
+		})
+	}
+}

--- a/app/exemptions_test.go
+++ b/app/exemptions_test.go
@@ -26,6 +26,7 @@ func TestShouldPokemonNameBeHyphenated(t *testing.T) {
 		{"Provide a non-hypenated Pokémon name", "type: null", false},
 		{"Provide a non-hypenated Pokémon name", "iron LEAVES", false},
 		{"Provide a non-hypenated Pokémon name", "mew two", false},
+		{"Provide a non-hypenated Pokémon name", "tapu-koko", false},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
The first automated test case!

This will prove that, Pokémon names that should be hyphenated will be correctly checked against and returned as `true` to the `transformer` class for correct name display.