### PR TITLE
Simplify the process for hyphenating (or not) a Pokemon's name

### DIFF
--- a/app/helpers.go
+++ b/app/helpers.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ConvertStringToTitleCase(stringToConvert string) string {
-	return cases.Title(language.Und, cases.NoLower).String(strings.ReplaceAll(stringToConvert, "-", " "))
+	return cases.Title(language.Und, cases.NoLower).String(stringToConvert)
 }
 
 func ConvertStringToKebabCase(stringToConvert string) string {

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -36,13 +36,14 @@ func Show(pokemon models.Pokemon) {
 }
 
 func printPokemonName(pokemonName string) {
-	transformedPokemonName := ConvertStringToTitleCase(pokemonName)
-
+	pokemonName = ConvertStringToTitleCase(pokemonName)
 	if ShouldPokemonNameBeHyphenated(pokemonName) == true {
-		transformedPokemonName = strings.ReplaceAll(transformedPokemonName, " ", "-")
+		pokemonName = strings.ReplaceAll(pokemonName, " ", "-")
+	} else {
+		pokemonName = strings.ReplaceAll(pokemonName, "-", " ")
 	}
 
-	fmt.Println("Name:", transformedPokemonName)
+	fmt.Println("Name:", pokemonName)
 }
 
 func printPokemonTypes(pokemonType models.Type, singleType bool) {


### PR DESCRIPTION
This change simplifies the process where the Pokemon's name is displayed with a hyphen or not. By removing the hypen-to-space conversion from the helper method, it ensures that the method does only what it says it does (Converting a string to TitleCase). I have then changed the `if` statement to check whether the Pokemon's name should be hyphenated or not and made the conversion for display there (I don't think this needs a helper method just yet, but we shall see further down the line). For example, `Ho-oh` should be displayed with a hyphen, whilst `Tapu Koko` should not.