### PR TITLE
Support the search and display of Pokemon names that contain punctuation marks or diacritics

### DIFF
--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -2,6 +2,26 @@ package app
 
 import "strings"
 
+func SanitisePokemonNameForSearch(pokemonName string) string {
+	switch strings.ToLower(pokemonName) {
+	case "farfetch'd":
+		return "farfetchd"
+	case "flabebé", "flabébe", "flabébé":
+		return "flabebe"
+	case "mimejr", "mimejr.", "mime jr.":
+		return "mime-jr"
+	case "mrmime", "mr.mime", "mr. mime":
+		return "mr-mime"
+	case "mrrime", "mr.rime", "mr. rime":
+		return "mr-rime"
+	case "sirfetch'd":
+		return "sirfetchd"
+	case "typenull", "type:null", "type: null":
+		return "type-null"
+	}
+	return pokemonName
+}
+
 func ShouldPokemonNameBeHyphenated(pokemonName string) bool {
 	switch strings.ToLower(pokemonName) {
 	case

--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -39,3 +39,24 @@ func ShouldPokemonNameBeHyphenated(pokemonName string) bool {
 
 	return false
 }
+
+func DisplayPokemonNameWithPunctuationMarkIfNeeded(pokemonName string) string {
+	switch strings.ToLower(pokemonName) {
+	case "farfetchd":
+		return "farfetch'd"
+	case "flabebe":
+		return "flabébé"
+	case "mime-jr":
+		return "mime jr."
+	case "mr-mime":
+		return "mr. mime"
+	case "mr-rime":
+		return "mr. rime"
+	case "sirfetchd":
+		return "sirfetch'd"
+	case "type-null":
+		return "type: null"
+	}
+
+	return pokemonName
+}

--- a/app/transformer.go
+++ b/app/transformer.go
@@ -36,6 +36,8 @@ func Show(pokemon models.Pokemon) {
 }
 
 func printPokemonName(pokemonName string) {
+	pokemonName = DisplayPokemonNameWithPunctuationMarkIfNeeded(pokemonName)
+
 	pokemonName = ConvertStringToTitleCase(pokemonName)
 	if ShouldPokemonNameBeHyphenated(pokemonName) == true {
 		pokemonName = strings.ReplaceAll(pokemonName, " ", "-")

--- a/main.go
+++ b/main.go
@@ -18,5 +18,6 @@ func main() {
 	}
 	enteredPokemonNameOrPokedexNumber := strings.TrimSuffix(consoleInput, "\n")
 
-	app.Show(app.FindPokemon(enteredPokemonNameOrPokedexNumber))
+	sanitisedPokemonName := app.SanitisePokemonNameForSearch(enteredPokemonNameOrPokedexNumber)
+	app.Show(app.FindPokemon(sanitisedPokemonName))
 }


### PR DESCRIPTION
There are several edge-cases of Pokemon's names which contain punctuation marks (such as `Mr. Mime`, or `Type: Null`) where we need to sanitise the name for searching against the API, and then transform it nicely so that it can be displayed to the user again with the correct punctuation. This change also supports Pokemon which have diacritics (currently only `Flabébé`).