### PR TITLE
Prompt the user to clarify if they provide a Pokemon name with form or gender changes

### DIFF
--- a/app/exemptions.go
+++ b/app/exemptions.go
@@ -1,6 +1,59 @@
 package app
 
-import "strings"
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+func ClarifyPokemonNameForSearch(pokemonName string) string {
+	switch strings.ToLower(pokemonName) {
+	case "nidoran":
+		for {
+			fmt.Println("Did you mean Nidoran♀ or Nidoran♂?")
+
+			nidoranGenderInput, err := bufio.NewReader(os.Stdin).ReadString('\n')
+			if err != nil {
+				log.Fatal("An unexpected error occurred:", err)
+			}
+			enteredNidoranGender := strings.TrimSpace(strings.ToLower(nidoranGenderInput))
+
+			if enteredNidoranGender == "♀" || enteredNidoranGender == "female" || enteredNidoranGender == "f" {
+				pokemonName = "nidoran-f"
+				break
+			} else if enteredNidoranGender == "♂" || enteredNidoranGender == "male" || enteredNidoranGender == "m" {
+				pokemonName = "nidoran-m"
+				break
+			} else {
+				fmt.Println("Invalid gender input. Please enter '♀', '♂', 'female' or 'male'")
+			}
+		}
+	case "morpeko":
+		for {
+			fmt.Println("Did you mean Morpeko Hangry Mode or Morpeko Full Belly Mode?")
+
+			morpekoModeInput, err := bufio.NewReader(os.Stdin).ReadString('\n')
+			if err != nil {
+				log.Fatal("An unexpected error occurred:", err)
+			}
+			enteredMorpekoMode := strings.TrimSpace(strings.ToLower(morpekoModeInput))
+
+			if enteredMorpekoMode == "hangry mode" || enteredMorpekoMode == "hangry" {
+				pokemonName = "morpeko-hangry"
+				break
+			} else if enteredMorpekoMode == "full belly mode" || enteredMorpekoMode == "full belly" {
+				pokemonName = "morpeko-full-belly"
+				break
+			} else {
+				fmt.Println("Invalid mode input. Please enter 'Hangry Mode' or 'Full Belly Mode'")
+			}
+		}
+	}
+
+	return pokemonName
+}
 
 func SanitisePokemonNameForSearch(pokemonName string) string {
 	switch strings.ToLower(pokemonName) {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	}
 	enteredPokemonNameOrPokedexNumber := strings.TrimSuffix(consoleInput, "\n")
 
-	sanitisedPokemonName := app.SanitisePokemonNameForSearch(enteredPokemonNameOrPokedexNumber)
+	clarifiedPokemonName := app.ClarifyPokemonNameForSearch(enteredPokemonNameOrPokedexNumber)
+	sanitisedPokemonName := app.SanitisePokemonNameForSearch(clarifiedPokemonName)
 	app.Show(app.FindPokemon(sanitisedPokemonName))
 }


### PR DESCRIPTION
There are many edge-cases now, and increasingly so as Game Freak add new ones, where a Pokemon may have more than one possible form. This change begins the work to account for all of these edge-cases and asks the user to clarify if it isn't clear which gender/form/variant they want to see information about.

To begin with, I have included additional prompts for Nidoran, which has two gender-specific versions, and Morpeko, which has two distinct forms (there isn't a 'normal' version of Morpeko, only two different forms of the same species)